### PR TITLE
Applying consistent avatar display update

### DIFF
--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -77,13 +77,20 @@
                                 <div class="player-name">
                                     @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
+                                            @php
+                                                $avatarUrl = $steamProfile->avatarfull ?? 'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
+                                            @endphp
                                             @if ($steamProfile->avatarfull)
                                                 <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar" rel="nofollow">
                                                     <div class="profile-avatar-fx"></div>
-                                                    <div class="profile-avatar-image" style="background-image: url('{{ $steamProfile->avatarfull }}')"></div>
+                                                    <div class="profile-avatar-image" style="background-image: url('{{ $avatarUrl }}')"></div>
                                                 </a>
+                                            @else
+                                                <div class="profile-avatar">
+                                                    <div class="profile-avatar-fx"></div>
+                                                    <div class="profile-avatar-image" style="background-image: url('{{ $avatarUrl }}')"></div>
+                                                </div>
                                             @endif
-
                                             <h3>
                                                 {{ \App\ViewHelper::renderSpecialOctal($steamProfile->personaname) }}
                                             </h3>


### PR DESCRIPTION
Currently when a user does not have an active steam profile their avatar is completly removed from the leaderboard leaving it with misaligned data. This PR aims to keep in the default steam no avatar icon for consistency (with disabled href)



Before Update:

![image](https://github.com/user-attachments/assets/1b8945bc-c4d6-4b3d-947b-db2afa117baa)


After Update:

![image](https://github.com/user-attachments/assets/08dc8432-87fa-46d3-83dc-eba80a79191f)

