### PR TITLE
[Needs Feedback] Enabling Season Select / Win Rate / Navbar Cleanup

### DIFF
--- a/src/app/Http/Controllers/LadderController.php
+++ b/src/app/Http/Controllers/LadderController.php
@@ -33,7 +33,8 @@ class LadderController extends Controller
      */
     public function extractSeasonNumber($seasonString)
     {
-        if (preg_match('/_(\d+)$/', $seasonString, $matches)) {
+        if (preg_match('/_(\d+)$/', $seasonString, $matches))
+        {
             return (int) $matches[1];
         }
         return null;
@@ -74,7 +75,7 @@ class LadderController extends Controller
 
         $latestSeasons = $this->nineBitArmiesAPI->getLatestSeason();
         $latestSeason = $this->extractSeasonNumber($latestSeasons['9bitarmies']);
-        
+
         // Use the season from the URL if provided, otherwise default to the latest season
         $currentSeason = $season ?? $latestSeason;
 
@@ -113,7 +114,7 @@ class LadderController extends Controller
         $gameName = $game == "red-alert" ? "Red Alert Remastered" : "Tiberian Dawn Remastered";
         $latestSeasons = $this->remastersAPI->getLatestSeason();
         $latestSeason = $game == "red-alert" ? $this->extractSeasonNumber($latestSeasons['RedAlert']) : $this->extractSeasonNumber($latestSeasons['TiberianDawn']);
-        
+
         // Use the season from the URL if provided, otherwise default to the latest season
         $currentSeason = $season ?? $latestSeason;
 
@@ -150,7 +151,7 @@ class LadderController extends Controller
         $gameName = $game == "red-alert" ? "Red Alert Remastered" : "Tiberian Dawn Remastered";
         $latestSeasons = $this->remastersAPI->getLatestSeason();
         $latestSeason = $game == "red-alert" ? $this->extractSeasonNumber($latestSeasons['RedAlert']) : $this->extractSeasonNumber($latestSeasons['TiberianDawn']);
-        
+
         // Use the season from the URL if provided, otherwise default to the latest season
         $currentSeason = $season ?? $latestSeason;
 
@@ -183,28 +184,30 @@ class LadderController extends Controller
             $steamIds[] = $d->steamids[0];
         }
 
+        $heroVideo = Constants::getVideoWithPoster("nine-bit-armies");
+
         $steamLookup = $this->petroglyphSteamProfileService->getSteamProfilesByIds($steamIds);
-        
+
         $latestSeasons = $this->nineBitArmiesAPI->getLatestSeason();
         $latestSeason = $this->extractSeasonNumber($latestSeasons['9bitarmies']);
-        
+
         // Use the season from the URL if provided, otherwise default to the latest season
         $currentSeason = $season ?? $latestSeason;
 
         return view(
-            'pages.remasters.ladder.listings',
+            'pages.9bitarmies.ladder.listings',
             [
                 'data' => $data,
                 'steamLookup' => $steamLookup,
                 'gameName' => '9-Bit Armies: A Bit Too Far',
-                'abbrev' => '9bitarmies',
+                'heroVideo' => $heroVideo,
                 'latestSeason' => $latestSeason,
                 'currentSelectedSeason' => $currentSeason
             ]
         );
     }
 
-    
+
     /**
      * Sync via cron task
      * @param mixed $steamIds 
@@ -239,16 +242,18 @@ class LadderController extends Controller
      * @throws GuzzleException
      */
     private function syncGameLeaderboard($boardPrefix, $latestSeason, $is9bit = false)
-    {   
+    {
         $steamIds = [];
 
-        for ($season = 1; $season <= $latestSeason; $season++) {
+        for ($season = 1; $season <= $latestSeason; $season++)
+        {
             $seasonBoardName = $boardPrefix . str_pad($season, 2, '0', STR_PAD_LEFT);
             // diff api calls depending if its 9bit or not, can make this more dynamic as needed by changing function signature, defaults to remasteredAPI
             $data = $is9bit ? $this->nineBitArmiesAPI->sendLeaderboardRequest($seasonBoardName, 200, 0) : $this->remastersAPI->sendLeaderboardRequest($seasonBoardName, 200, 0);
             $data = json_decode(json_encode($data["ranks"]));
 
-            foreach ($data as $d) {
+            foreach ($data as $d)
+            {
                 $steamIds[] = $d->steamids[0];
             }
         }
@@ -263,7 +268,7 @@ class LadderController extends Controller
      * @throws GuzzleException 
      */
     public function syncNineBitArmies()
-    {   
+    {
         $latestSeasons = $this->nineBitArmiesAPI->getLatestSeason();
         $latestSeason = isset($latestSeasons['9bitarmies']) ? $this->extractSeasonNumber($latestSeasons['9bitarmies']) : 2;
 

--- a/src/app/Http/Services/Petroglyph/NineBitArmiesAPI.php
+++ b/src/app/Http/Services/Petroglyph/NineBitArmiesAPI.php
@@ -35,7 +35,7 @@ class NineBitArmiesAPI
         return [];
     }
 
-    private function getLatestSeason()
+    public function getLatestSeason()
     {
         $client = new Client();
         $response = $client->request('GET', $this->_allSeasonLeaderboardUrls, [
@@ -85,7 +85,7 @@ class NineBitArmiesAPI
         }
     }
 
-    private function sendLeaderboardRequest(string $boardName, int $limit = 200, int $offset = 0)
+    public function sendLeaderboardRequest(string $boardName, int $limit = 200, int $offset = 0)
     {
         try
         {

--- a/src/app/Http/Services/Petroglyph/RemastersAPI.php
+++ b/src/app/Http/Services/Petroglyph/RemastersAPI.php
@@ -102,7 +102,7 @@ class RemastersAPI
         }
     }
 
-    private function sendLeaderboardRequest(string $boardName, int $limit = 200, int $offset = 0)
+    public function sendLeaderboardRequest(string $boardName, int $limit = 200, int $offset = 0)
     {
         try
         {

--- a/src/app/Http/Services/Petroglyph/RemastersAPI.php
+++ b/src/app/Http/Services/Petroglyph/RemastersAPI.php
@@ -49,7 +49,7 @@ class RemastersAPI
         return [];
     }
 
-    private function getLatestSeason()
+    public function getLatestSeason()
     {
         $client = new Client();
         $response = $client->request('GET', $this->_allSeasonLeaderboardUrls, [

--- a/src/resources/views/layouts/navigation/main-menu.blade.php
+++ b/src/resources/views/layouts/navigation/main-menu.blade.php
@@ -32,12 +32,6 @@
                     <a href="/command-and-conquer-remastered#streams" title="C&C Streams">Streams</a>
                     <a href="/command-and-conquer-remastered/workshop-mods" title="Steam Workshop">Steam Workshop</a>
                     <a href="/command-and-conquer-remastered#help" title="Help & Support">Help &amp; Support</a>
-
-                    <div class="title" style="margin-top:10px;">
-                        Leaderboard
-                    </div>
-                    <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard">Tiberian Dawn</a>
-                    <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Red Alert Leaderboard">Red Alert</a>
                 </div>
 
                 <div class="category">
@@ -47,10 +41,12 @@
                     <a href="https://petroglyphgames.com/" title="Visit Website" target="_blank">Visit Website</a>
 
                     <div class="title" style="margin-top:10px;">
-                        Leaderboard
+                        Leaderboards
                     </div>
                     {{-- <a href="{{ route('8bit.leaderboard') }}" title="Leaderboard">8-BIT ARMIES</a> --}}
-                    <a href="{{ route('9bit.leaderboard') }}" title="Leaderboard">9-BIT ARMIES: A BIT TOO FAR</a>
+                    <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard">Tiberian Dawn</a>
+                    <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Red Alert Leaderboard">Red Alert</a>
+                    <a href="{{ route('9bit.leaderboard') }}" title="Leaderboard">9-Bit Armies: A Bit Too Far</a>
                 </div>
             </div>
         </div>

--- a/src/resources/views/layouts/navigation/main-menu.blade.php
+++ b/src/resources/views/layouts/navigation/main-menu.blade.php
@@ -46,7 +46,7 @@
                     {{-- <a href="{{ route('8bit.leaderboard') }}" title="Leaderboard">8-BIT ARMIES</a> --}}
                     <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard">Tiberian Dawn</a>
                     <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Red Alert Leaderboard">Red Alert</a>
-                    <a href="{{ route('9bit.leaderboard') }}" title="Leaderboard">9-Bit Armies: A Bit Too Far</a>
+                    <a href="/9bitarmies/leaderboard" title="9-Bit Leaderboard">9-Bit Armies: A Bit Too Far</a>
                 </div>
             </div>
         </div>

--- a/src/resources/views/layouts/navigation/mobile-menu.blade.php
+++ b/src/resources/views/layouts/navigation/mobile-menu.blade.php
@@ -27,10 +27,6 @@
         <a href="/command-and-conquer-remastered#streams" title="C&C Streams" class="nav-link">Streams</a>
         <a href="/command-and-conquer-remastered/workshop-mods" title="C&C Mods" class="nav-link">Steam Workshop</a>
         <a href="/command-and-conquer-remastered#help" title="Help & Support" class="nav-link">Help &amp; Support</a>
-        <div class="title"><a href="/command-and-conquer-remastered/leaderboard"title="C&C Remastered Leaderboard">C&amp;C Remastered
-                Leaderboard</a></div>
-        <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard" class="nav-link">Tiberian Dawn</a>
-        <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Tiberian Dawn Leaderboard" class="nav-link">Red Alert</a>
     </div>
 
 
@@ -39,10 +35,14 @@
             <a href="https://petroglyphgames.com/" title="Petroglyph website">Petroglyph</a>
         </div>
         <a href="https://petroglyphgames.com/" title="Visit Website" target="_blank" class="nav-link">Visit Website</a>
-
+    </div>
+    
+    <div class="category">
         <div class="title" style="margin-top:10px;">
-            Leaderboard
+            Leaderboards
         </div>
+        <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard" class="nav-link">Tiberian Dawn</a>
+        <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Tiberian Dawn Leaderboard" class="nav-link">Red Alert</a>
         <a href="{{ route('9bit.leaderboard') }}" title="Leaderboard" class="nav-link">9-BIT ARMIES: A BIT TOO FAR</a>
     </div>
 

--- a/src/resources/views/layouts/navigation/mobile-menu.blade.php
+++ b/src/resources/views/layouts/navigation/mobile-menu.blade.php
@@ -36,14 +36,14 @@
         </div>
         <a href="https://petroglyphgames.com/" title="Visit Website" target="_blank" class="nav-link">Visit Website</a>
     </div>
-    
+
     <div class="category">
         <div class="title" style="margin-top:10px;">
             Leaderboards
         </div>
         <a href="/command-and-conquer-remastered/leaderboard/tiberian-dawn" title="Tiberian Dawn Leaderboard" class="nav-link">Tiberian Dawn</a>
-        <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Tiberian Dawn Leaderboard" class="nav-link">Red Alert</a>
-        <a href="{{ route('9bit.leaderboard') }}" title="Leaderboard" class="nav-link">9-BIT ARMIES: A BIT TOO FAR</a>
+        <a href="/command-and-conquer-remastered/leaderboard/red-alert" title="Red Alert Leaderboard" class="nav-link">Red Alert</a>
+        <a href="/9bitarmies/leaderboard" title="9-Bit Leaderboard" class="nav-link">9-Bit Armies: A Bit Too Far</a>
     </div>
 
     <div class="category">

--- a/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
+++ b/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
@@ -58,11 +58,12 @@
                 <div class="leaderboard-listings">
                     <div class="headers">
                         <div class="col col-10 rank">Rank</div>
-                        <div class="col col-40">Name</div>
+                        <div class="col col-30">Name</div>
                         <div class="col col-10">Points</div>
                         <div class="col col-10">Wins</div>
                         <div class="col col-10">Losses</div>
                         <div class="col col-10">Played</div>
+                        <div class="col col-10">Win Rate</div>
                         <div class="col col-10">History</div>
                         {{-- <div class="col col-10"></div> --}}
                     </div>
@@ -76,17 +77,24 @@
                                 </div>
                             </div>
 
-                            <div class="col col-40 visible-lg">
+                            <div class="col col-30 visible-lg">
                                 <div class="player-name">
-                                    @foreach ($steamLookup as $steamProfile)
+                                @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
+                                            @php
+                                                $avatarUrl = $steamProfile->avatarfull ?? 'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
+                                            @endphp
                                             @if ($steamProfile->avatarfull)
                                                 <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar" rel="nofollow">
                                                     <div class="profile-avatar-fx"></div>
-                                                    <div class="profile-avatar-image" style="background-image: url('{{ $steamProfile->avatarfull }}')"></div>
+                                                    <div class="profile-avatar-image" style="background-image: url('{{ $avatarUrl }}')"></div>
                                                 </a>
+                                            @else
+                                                <div class="profile-avatar">
+                                                    <div class="profile-avatar-fx"></div>
+                                                    <div class="profile-avatar-image" style="background-image: url('{{ $avatarUrl }}')"></div>
+                                                </div>
                                             @endif
-
                                             <h3>
                                                 {{ \App\ViewHelper::renderSpecialOctal($steamProfile->personaname) }}
                                             </h3>
@@ -110,6 +118,18 @@
                             <div class="col col-10 visible-lg">
                                 <div class="played">{{ $player->wins += $player->loses }}</div>
                             </div>
+
+                            <div class="col col-10 visible-lg">
+                                <div class="win-rate">
+                                    @php
+                                        $totalGames = $player->wins + $player->loses;
+                                        $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
+                                        $roundedWinRate = ceil($winRate);
+                                    @endphp
+                                    {{ $roundedWinRate }}%
+                                </div>
+                            </div>
+
                             {{--
                             <div class="col col-10 visible-lg">
                                  <i class="icon icon-right"></i>
@@ -168,6 +188,38 @@
                                             <div class="losses"><strong>Losses:</strong> {{ $player->loses }}</div>
                                             <div class="played"><strong>Played:</strong> {{ $player->wins += $player->loses }}</div>
                                             <div class="points"><strong>Points:</strong> {{ round($player->points) }}</div>
+                                            <div class="win-rate"><strong>Win Rate:</strong> 
+                                                @php
+                                                    $totalGames = $player->wins + $player->loses;
+                                                    $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
+                                                    $roundedWinRate = ceil($winRate);
+                                                @endphp
+                                                {{ $roundedWinRate }}%
+                                            </div>
+                                            <div class="history"><strong>History:</strong>
+                                                @php
+                                                    $rankHistory = array_splice($player->rankhistory, -1);
+                                                @endphp
+                                                @foreach ($rankHistory as $rank)
+                                                    @if ($rank !== $player->rank)
+                                                        @if ($rank > $player->rank)
+                                                            <span class="rank-history rank-green" style="color: #01ad00;">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#01ad00">
+                                                                    <path d="m280-400 200-200 200 200H280Z" />
+                                                                </svg>
+                                                                #{{ $rank }}
+                                                            </span>
+                                                        @else
+                                                            <span class="rank-history rank-red" style="color: #ad0036;">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#ad0036">
+                                                                    <path d="M480-360 280-560h400L480-360Z" />
+                                                                </svg>
+                                                                #{{ $rank }}
+                                                            </span>
+                                                        @endif
+                                                    @endif
+                                                @endforeach
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
+++ b/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
@@ -54,6 +54,27 @@
         </div>
 
         <div class="main-content">
+            <div class="season-selector" style="padding-left:40px; background: #001127e3; padding-bottom: 1em;">
+                <span>Current Selected Season <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
+                <label for="9bit-season">Previous Season Select</label><br/>
+                <select id="9bit-season" name="9bit-season" onchange="fetchSeasonNineBitData()">
+                    <option value="" disabled selected>-- Select Season --</option>
+                    @for ($i = 1; $i <= $latestSeason; $i++)
+                        <option value="{{ $i }}">Season {{ $i }}</option>
+                    @endfor
+                </select>
+            </div>
+        </div>
+
+        <script>
+            function fetchSeasonNineBitData() {
+                var season = document.getElementById('9bit-season').value;
+                var currentUrl = window.location.href;
+                window.location.href = `/9bitarmies/leaderboard/season/` + season;
+            }
+        </script>
+
+        <div class="main-content">
             <div class="leaderboard-player-listings">
                 <div class="leaderboard-listings">
                     <div class="headers">

--- a/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
+++ b/src/resources/views/pages/9bitarmies/ladder/listings.blade.php
@@ -54,13 +54,13 @@
         </div>
 
         <div class="main-content">
-            <div class="season-selector" style="padding-left:40px; background: #001127e3; padding-bottom: 1em;">
+            <div class="season-select" style="padding-left:40px; background: #001127e3; padding-bottom: 1em;">
                 <span>Current Selected Season <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
-                <label for="9bit-season">Previous Season Select</label><br/>
-                <select id="9bit-season" name="9bit-season" onchange="fetchSeasonNineBitData()">
+                <label for="season">Previous Season Select</label><br />
+                <select id="season" name="season" onchange="fetchSeasonNineBitData()" style="border: 1px solid #173081">
                     <option value="" disabled selected>-- Select Season --</option>
                     @for ($i = 1; $i <= $latestSeason; $i++)
-                        <option value="{{ $i }}">Season {{ $i }}</option>
+                        <option value="{{ $i }}" @if ($i == $currentSelectedSeason) selected @endif>Season {{ $i }}</option>
                     @endfor
                 </select>
             </div>
@@ -68,7 +68,7 @@
 
         <script>
             function fetchSeasonNineBitData() {
-                var season = document.getElementById('9bit-season').value;
+                var season = document.getElementById('season').value;
                 var currentUrl = window.location.href;
                 window.location.href = `/9bitarmies/leaderboard/season/` + season;
             }
@@ -100,10 +100,12 @@
 
                             <div class="col col-30 visible-lg">
                                 <div class="player-name">
-                                @foreach ($steamLookup as $steamProfile)
+                                    @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
                                             @php
-                                                $avatarUrl = $steamProfile->avatarfull ?? 'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
+                                                $avatarUrl =
+                                                    $steamProfile->avatarfull ??
+                                                    'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
                                             @endphp
                                             @if ($steamProfile->avatarfull)
                                                 <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar" rel="nofollow">
@@ -187,7 +189,8 @@
                                         @foreach ($steamLookup as $steamProfile)
                                             @if ($player->steamids[0] == $steamProfile->steam_id)
                                                 @if ($steamProfile->avatarfull)
-                                                    <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar" rel="nofollow">
+                                                    <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar"
+                                                        rel="nofollow">
                                                         <div class="profile-avatar-fx"></div>
                                                         <div class="profile-avatar-image" style="background-image: url('{{ $steamProfile->avatarfull }}')">
                                                         </div>
@@ -209,7 +212,7 @@
                                             <div class="losses"><strong>Losses:</strong> {{ $player->loses }}</div>
                                             <div class="played"><strong>Played:</strong> {{ $player->wins += $player->loses }}</div>
                                             <div class="points"><strong>Points:</strong> {{ round($player->points) }}</div>
-                                            <div class="win-rate"><strong>Win Rate:</strong> 
+                                            <div class="win-rate"><strong>Win Rate:</strong>
                                                 @php
                                                     $totalGames = $player->wins + $player->loses;
                                                     $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
@@ -225,14 +228,16 @@
                                                     @if ($rank !== $player->rank)
                                                         @if ($rank > $player->rank)
                                                             <span class="rank-history rank-green" style="color: #01ad00;">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#01ad00">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em"
+                                                                    fill="#01ad00">
                                                                     <path d="m280-400 200-200 200 200H280Z" />
                                                                 </svg>
                                                                 #{{ $rank }}
                                                             </span>
                                                         @else
                                                             <span class="rank-history rank-red" style="color: #ad0036;">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#ad0036">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em"
+                                                                    fill="#ad0036">
                                                                     <path d="M480-360 280-560h400L480-360Z" />
                                                                 </svg>
                                                                 #{{ $rank }}

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -9,6 +9,19 @@
     $slug = Str::slug($gameName);
     $imageClasses = ['hero-bg', 'hero-bg-1', 'hero-bg-2', 'hero-bg-3', 'hero-bg-4'];
     $randomImage = $imageClasses[array_rand($imageClasses)];
+    function getRankIcon($rank) {
+        if ($rank <= 16) {
+            return 'general.png';
+        } elseif ($rank <= 200) {
+            return 'major.png';
+        } elseif ($rank <= 400) {
+            return 'captain.png';
+        } elseif ($rank <= 600) {
+            return 'lieutenant.png';
+        } else {
+            return 'sergeant.png';
+        }
+    }
 @endphp
 
 @section('hero-video')
@@ -54,26 +67,32 @@
             <div class="leaderboard-player-listings">
                 <div class="leaderboard-listings">
                     <div class="headers">
+                        <div class="col col-10 rank"></div>
                         <div class="col col-10 rank">Rank</div>
-                        <div class="col col-40">Name</div>
+                        <div class="col col-20">Name</div>
                         <div class="col col-10">Points</div>
                         <div class="col col-10">Wins</div>
                         <div class="col col-10">Losses</div>
                         <div class="col col-10">Played</div>
+                        <div class="col col-10">Win Rate</div>
                         <div class="col col-10">History</div>
                         {{-- <div class="col col-10"></div> --}}
                     </div>
 
                     @foreach ($data as $player)
                         <div class="leaderboard-table-row @if ($player->rank == 1) gold @endif">
-
+                            <div class="col col-10 visible-lg">
+                                <div class="rank">
+                                    <img style="max-height: 4rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
+                                </div>
+                            </div>
                             <div class="col col-10 visible-lg">
                                 <div class="rank">
                                     <span style="font-size:1.4rem">#{{ $player->rank }}</span>
                                 </div>
                             </div>
 
-                            <div class="col col-40 visible-lg">
+                            <div class="col col-20 visible-lg">
                                 <div class="player-name">
                                     @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
@@ -114,6 +133,18 @@
                             <div class="col col-10 visible-lg">
                                 <div class="played">{{ $player->wins += $player->loses }}</div>
                             </div>
+
+                            <div class="col col-10 visible-lg">
+                                @php
+                                    $totalGames = $player->wins + $player->loses;
+                                    $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
+                                    $roundedWinRate = ceil($winRate);
+                                @endphp
+                                <div>
+                                    {{ $roundedWinRate }}%
+                                </div>
+                            </div>
+
                             {{--
                             <div class="col col-10 visible-lg">
                                  <i class="icon icon-right"></i>

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -203,6 +203,38 @@
                                             <div class="losses"><strong>Losses:</strong> {{ $player->loses }}</div>
                                             <div class="played"><strong>Played:</strong> {{ $player->wins += $player->loses }}</div>
                                             <div class="points"><strong>Points:</strong> {{ round($player->points) }}</div>
+                                            <div class="win-rate"><strong>Win Rate:</strong> 
+                                                @php
+                                                    $totalGames = $player->wins + $player->loses;
+                                                    $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
+                                                    $roundedWinRate = ceil($winRate);
+                                                @endphp
+                                                {{ $roundedWinRate }}%
+                                            </div>
+                                            <div class="history"><strong>History:</strong>
+                                                @php
+                                                    $rankHistory = array_splice($player->rankhistory, -1);
+                                                @endphp
+                                                @foreach ($rankHistory as $rank)
+                                                    @if ($rank !== $player->rank)
+                                                        @if ($rank > $player->rank)
+                                                            <span class="rank-history rank-green" style="color: #01ad00;">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#01ad00">
+                                                                    <path d="m280-400 200-200 200 200H280Z" />
+                                                                </svg>
+                                                                #{{ $rank }}
+                                                            </span>
+                                                        @else
+                                                            <span class="rank-history rank-red" style="color: #ad0036;">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#ad0036">
+                                                                    <path d="M480-360 280-560h400L480-360Z" />
+                                                                </svg>
+                                                                #{{ $rank }}
+                                                            </span>
+                                                        @endif
+                                                    @endif
+                                                @endforeach
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -65,7 +65,7 @@
 
         <div class="main-content">
             <div class="season-selector" style="padding-left:40px">
-                <span>Current Selected Season: <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
+                <span>Current Selected Season <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
                 <label for="season">Previous Season Select</label><br/>
                 <select id="season" name="season" onchange="fetchSeasonData()">
                     <option value="" disabled selected>-- Select Season --</option>
@@ -90,8 +90,7 @@
                 <div class="leaderboard-listings">
                     <div class="headers">
                         <div class="col col-10 rank">Rank</div>
-                        <div class="col col-10 rank">Position</div>
-                        <div class="col col-20">Name</div>
+                        <div class="col col-30">Name</div>
                         <div class="col col-10">Points</div>
                         <div class="col col-10">Wins</div>
                         <div class="col col-10">Losses</div>
@@ -103,18 +102,18 @@
 
                     @foreach ($data as $player)
                         <div class="leaderboard-table-row @if ($player->rank == 1) gold @endif">
-                            <div class="col col-10 visible-lg">
+                            <!-- <div class="col col-10 visible-lg">
                                 <div class="rank">
                                     <img style="max-height: 3.6rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
                                 </div>
-                            </div>
+                            </div> -->
                             <div class="col col-10 visible-lg">
                                 <div class="rank">
                                     <span style="font-size:1.4rem">#{{ $player->rank }} </span>
                                 </div>
                             </div>
 
-                            <div class="col col-20 visible-lg">
+                            <div class="col col-30 visible-lg">
                                 <div class="player-name">
                                     @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
@@ -133,23 +132,7 @@
                                                 </div>
                                             @endif
                                             <h3>
-                                                @if ($player->rank == 1)
-                                                    🎖️
-                                                @elseif ($player->rank == 2)
-                                                    🥈
-                                                @elseif ($player->rank == 3)
-                                                    🥉
-                                                @endif
-
                                                 {{ \App\ViewHelper::renderSpecialOctal($steamProfile->personaname) }}
-
-                                                @if ($player->rank == 1)
-                                                    🎖️
-                                                @elseif ($player->rank == 2)
-                                                    🥈
-                                                @elseif ($player->rank == 3)
-                                                    🥉
-                                                @endif
                                             </h3>
                                         @endif
                                     @endforeach

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -9,7 +9,8 @@
     $slug = Str::slug($gameName);
     $imageClasses = ['hero-bg', 'hero-bg-1', 'hero-bg-2', 'hero-bg-3', 'hero-bg-4'];
     $randomImage = $imageClasses[array_rand($imageClasses)];
-    function getRankIcon($rank) {
+    function getRankIcon($rank)
+    {
         if ($rank <= 16) {
             return 'general.png';
         } elseif ($rank <= 200) {
@@ -64,13 +65,13 @@
         </div>
 
         <div class="main-content">
-            <div class="season-selector" style="padding-left:40px">
+            <div class="season-select" style="padding-left:40px">
                 <span>Current Selected Season <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
-                <label for="season">Previous Season Select</label><br/>
+                <label for="season">Previous Season Select</label><br />
                 <select id="season" name="season" onchange="fetchSeasonData()">
                     <option value="" disabled selected>-- Select Season --</option>
                     @for ($i = 1; $i <= $latestSeason; $i++)
-                        <option value="{{ $i }}">Season {{ $i }}</option>
+                        <option value="{{ $i }}" @if ($i == $currentSelectedSeason) selected @endif>Season {{ $i }}</option>
                     @endfor
                 </select>
             </div>
@@ -103,10 +104,10 @@
                     @foreach ($data as $player)
                         <div class="leaderboard-table-row @if ($player->rank == 1) gold @endif">
                             <!-- <div class="col col-10 visible-lg">
-                                <div class="rank">
-                                    <img style="max-height: 3.6rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
-                                </div>
-                            </div> -->
+                                            <div class="rank">
+                                                <img style="max-height: 3.6rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
+                                            </div>
+                                        </div> -->
                             <div class="col col-10 visible-lg">
                                 <div class="rank">
                                     <span style="font-size:1.4rem">#{{ $player->rank }} </span>
@@ -118,7 +119,9 @@
                                     @foreach ($steamLookup as $steamProfile)
                                         @if ($player->steamids[0] == $steamProfile->steam_id)
                                             @php
-                                                $avatarUrl = $steamProfile->avatarfull ?? 'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
+                                                $avatarUrl =
+                                                    $steamProfile->avatarfull ??
+                                                    'https://avatars.akamai.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg';
                                             @endphp
                                             @if ($steamProfile->avatarfull)
                                                 <a href="https://steamcommunity.com/profiles/{{ $player->steamids[0] }}" class="profile-avatar" rel="nofollow">
@@ -224,7 +227,7 @@
                                             <div class="losses"><strong>Losses:</strong> {{ $player->loses }}</div>
                                             <div class="played"><strong>Played:</strong> {{ $player->wins += $player->loses }}</div>
                                             <div class="points"><strong>Points:</strong> {{ round($player->points) }}</div>
-                                            <div class="win-rate"><strong>Win Rate:</strong> 
+                                            <div class="win-rate"><strong>Win Rate:</strong>
                                                 @php
                                                     $totalGames = $player->wins + $player->loses;
                                                     $winRate = $totalGames > 0 ? ($player->wins / $totalGames) * 100 : 0;
@@ -240,14 +243,16 @@
                                                     @if ($rank !== $player->rank)
                                                         @if ($rank > $player->rank)
                                                             <span class="rank-history rank-green" style="color: #01ad00;">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#01ad00">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em"
+                                                                    fill="#01ad00">
                                                                     <path d="m280-400 200-200 200 200H280Z" />
                                                                 </svg>
                                                                 #{{ $rank }}
                                                             </span>
                                                         @else
                                                             <span class="rank-history rank-red" style="color: #ad0036;">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em" fill="#ad0036">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 -960 960 960" width="1em"
+                                                                    fill="#ad0036">
                                                                     <path d="M480-360 280-560h400L480-360Z" />
                                                                 </svg>
                                                                 #{{ $rank }}

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -62,6 +62,24 @@
                 </div>
             </div>
         </div>
+        
+        <div class="main-content">
+            <div class="season-selector" style="padding-left:40px">
+                <label for="season">Previous Season Select</label><br/>
+                <select id="season" name="season" onchange="fetchSeasonData()">
+                    @for ($i = 1; $i <= 18; $i++)
+                        <option value="{{ $i }}">Season {{ $i }}</option>
+                    @endfor
+                </select>
+            </div>
+        </div>
+
+        <script>
+            function fetchSeasonData() {
+                var season = document.getElementById('season').value;
+                window.location.href = '/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/' + season;
+            }
+        </script>
 
         <div class="main-content">
             <div class="leaderboard-player-listings">
@@ -120,7 +138,7 @@
                                                 @endif
 
                                                 {{ \App\ViewHelper::renderSpecialOctal($steamProfile->personaname) }}
-                                                
+
                                                 @if ($player->rank == 1)
                                                     🎖️
                                                 @elseif ($player->rank == 2)

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -62,12 +62,14 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="main-content">
             <div class="season-selector" style="padding-left:40px">
+                <span>Current Selected Season: <br /><strong>Season {{ $currentSelectedSeason }}</strong></span><br /><br />
                 <label for="season">Previous Season Select</label><br/>
                 <select id="season" name="season" onchange="fetchSeasonData()">
-                    @for ($i = 1; $i <= 18; $i++)
+                    <option value="" disabled selected>-- Select Season --</option>
+                    @for ($i = 1; $i <= $latestSeason; $i++)
                         <option value="{{ $i }}">Season {{ $i }}</option>
                     @endfor
                 </select>
@@ -77,7 +79,9 @@
         <script>
             function fetchSeasonData() {
                 var season = document.getElementById('season').value;
-                window.location.href = '/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/' + season;
+                var currentUrl = window.location.href;
+                var game = currentUrl.includes('tiberian-dawn') ? 'tiberian-dawn' : 'red-alert';
+                window.location.href = `/command-and-conquer-remastered/leaderboard/${game}/season/` + season;
             }
         </script>
 
@@ -86,7 +90,7 @@
                 <div class="leaderboard-listings">
                     <div class="headers">
                         <div class="col col-10 rank">Rank</div>
-                        <div class="col col-10 rank">Poisition</div>
+                        <div class="col col-10 rank">Position</div>
                         <div class="col col-20">Name</div>
                         <div class="col col-10">Points</div>
                         <div class="col col-10">Wins</div>

--- a/src/resources/views/pages/remasters/ladder/listings.blade.php
+++ b/src/resources/views/pages/remasters/ladder/listings.blade.php
@@ -67,8 +67,8 @@
             <div class="leaderboard-player-listings">
                 <div class="leaderboard-listings">
                     <div class="headers">
-                        <div class="col col-10 rank"></div>
                         <div class="col col-10 rank">Rank</div>
+                        <div class="col col-10 rank">Poisition</div>
                         <div class="col col-20">Name</div>
                         <div class="col col-10">Points</div>
                         <div class="col col-10">Wins</div>
@@ -83,12 +83,12 @@
                         <div class="leaderboard-table-row @if ($player->rank == 1) gold @endif">
                             <div class="col col-10 visible-lg">
                                 <div class="rank">
-                                    <img style="max-height: 4rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
+                                    <img style="max-height: 3.6rem" src="https://raw.githubusercontent.com/cnc-community/cnc.community/master/src/resources/assets/images/leaderboard/{{ getRankIcon($player->rank) }}" alt="Rank Icon" />
                                 </div>
                             </div>
                             <div class="col col-10 visible-lg">
                                 <div class="rank">
-                                    <span style="font-size:1.4rem">#{{ $player->rank }}</span>
+                                    <span style="font-size:1.4rem">#{{ $player->rank }} </span>
                                 </div>
                             </div>
 
@@ -111,7 +111,23 @@
                                                 </div>
                                             @endif
                                             <h3>
+                                                @if ($player->rank == 1)
+                                                    🎖️
+                                                @elseif ($player->rank == 2)
+                                                    🥈
+                                                @elseif ($player->rank == 3)
+                                                    🥉
+                                                @endif
+
                                                 {{ \App\ViewHelper::renderSpecialOctal($steamProfile->personaname) }}
+                                                
+                                                @if ($player->rank == 1)
+                                                    🎖️
+                                                @elseif ($player->rank == 2)
+                                                    🥈
+                                                @elseif ($player->rank == 3)
+                                                    🥉
+                                                @endif
                                             </h3>
                                         @endif
                                     @endforeach

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -94,6 +94,8 @@ Route::get('/8bitarmies/leaderboard', 'LadderController@getEightBitArmiesIndex')
 Route::get('/9bitarmies/leaderboard', 'LadderController@getNineBitArmiesIndex')->name('9bit.leaderboard');
 Route::get('/command-and-conquer-remastered/leaderboard/{game}', 'LadderController@getRemasteredIndex')->middleware('cache.headers:public;max_age=480');
 
+Route::get('/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/{season}', 'LadderController@getSpecificSeasonTDLeaderboard');
+
 Route::get('/cnc-streamers', 'SiteController@showCreatorsListings')->name('pages.creators.listing')->middleware('cache.headers:public;max_age=1800');
 Route::get('/creators', function ()
 {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -80,7 +80,6 @@ Route::group(['prefix' => 'admin', 'middleware' => ['admin']], function ()
 });
 
 
-//
 // Public routes
 Route::get('/', 'SiteController@index')->name('home')->middleware('cache.headers:public;max_age=1800');
 Route::get('/funny', 'SiteController@showFunnyListings')->name('pages.funny.listing')->middleware('cache.headers:public;max_age=3600');
@@ -94,7 +93,9 @@ Route::get('/8bitarmies/leaderboard', 'LadderController@getEightBitArmiesIndex')
 Route::get('/9bitarmies/leaderboard', 'LadderController@getNineBitArmiesIndex')->name('9bit.leaderboard');
 Route::get('/command-and-conquer-remastered/leaderboard/{game}', 'LadderController@getRemasteredIndex')->middleware('cache.headers:public;max_age=480');
 
-Route::get('/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/{season}', 'LadderController@getSpecificSeasonTDLeaderboard');
+// Season specific Leaderboards for Remasters
+Route::get('/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/{season}', 'LadderController@getSpecificSeasonLeaderboard')->defaults('game', 'tiberian-dawn');;
+Route::get('/command-and-conquer-remastered/leaderboard/red-alert/season/{season}', 'LadderController@getSpecificSeasonLeaderboard')->defaults('game', 'red-alert');;
 
 Route::get('/cnc-streamers', 'SiteController@showCreatorsListings')->name('pages.creators.listing')->middleware('cache.headers:public;max_age=1800');
 Route::get('/creators', function ()

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -88,14 +88,15 @@ Route::get('/stats', 'StatsController@showStats')->name('pages.stats')->middlewa
 Route::get('/command-and-conquer-ultimate-collection-steam', 'SiteController@showTUCPage')->name('pages.tuc')->middleware('cache.headers:public;max_age=400');
 Route::get('/command-and-conquer-ultimate-collection-online', 'SiteController@showTUCMultiplayerPage')->name('pages.tucMultiplayer')->middleware('cache.headers:public;max_age=400');
 
-// Petro games
+// Petro Leaderboards
 Route::get('/8bitarmies/leaderboard', 'LadderController@getEightBitArmiesIndex')->name('8bit.leaderboard');
 Route::get('/9bitarmies/leaderboard', 'LadderController@getNineBitArmiesIndex')->name('9bit.leaderboard');
-Route::get('/command-and-conquer-remastered/leaderboard/{game}', 'LadderController@getRemasteredIndex')->middleware('cache.headers:public;max_age=480');
+Route::get('/9bitarmies/leaderboard/season/{season}', 'LadderController@getSpecificNineBitSeasonLeaderboard')->defaults('game', '9bit');
 
-// Season specific Leaderboards for Remasters
-Route::get('/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/{season}', 'LadderController@getSpecificSeasonLeaderboard')->defaults('game', 'tiberian-dawn');;
-Route::get('/command-and-conquer-remastered/leaderboard/red-alert/season/{season}', 'LadderController@getSpecificSeasonLeaderboard')->defaults('game', 'red-alert');;
+// C&C Leaderboards
+Route::get('/command-and-conquer-remastered/leaderboard/{game}', 'LadderController@getRemasteredIndex')->middleware('cache.headers:public;max_age=480');
+Route::get('/command-and-conquer-remastered/leaderboard/tiberian-dawn/season/{season}', 'LadderController@getSpecificRemasteredSeasonLeaderboard')->defaults('game', 'tiberian-dawn');
+Route::get('/command-and-conquer-remastered/leaderboard/red-alert/season/{season}', 'LadderController@getSpecificRemasteredSeasonLeaderboard')->defaults('game', 'red-alert');
 
 Route::get('/cnc-streamers', 'SiteController@showCreatorsListings')->name('pages.creators.listing')->middleware('cache.headers:public;max_age=1800');
 Route::get('/creators', function ()


### PR DESCRIPTION
This PR adds the following:

Leaderboard Updates:
* Adds additional column 'Win Rate' to TD, RA & 9Bit Leaderboards
* Adds Season Select options to TD, RA & 9Bit Leaderboards
* Refactored order of Navbar Elements for Consistency
* Refactored Index 9bit & Remaster Sync Jobs to account for all seasons not just latest. (prevent blank names/profiles outside of latest season).

---

Current Issue:
* While RA/TD season select is functioning as expected, the 9bit season select is bugged. When user clicks on older season it attempts to load in the remastered blade despite routes being defined correctly within the web.php and listings.blade.php files. (I've also tested this passing through the required missing props, and it loads up a weird hybridised version of the s1 leaderboard injecting the 9bit data into the remastered styled tables.)

---

Navbar Before:

![image](https://github.com/user-attachments/assets/6f15df78-c517-4e1e-81ea-c3bce6a35014)
![image](https://github.com/user-attachments/assets/22639950-0d21-4a37-afb6-dd6bf587194a)


Navbar After:

![image](https://github.com/user-attachments/assets/82187729-eed7-42d4-ba18-aa9b1f287172)
![image](https://github.com/user-attachments/assets/c627c33d-3d72-4f8d-8c49-9e3bc85cced5)


---

TD Leaderboard Before:

![image](https://github.com/user-attachments/assets/0bf53b92-5b02-4aa4-a90d-63eacfb06cfb)
![image](https://github.com/user-attachments/assets/87a3c2d2-e6eb-4850-9436-0ca92de3686b)


TD Leaderboard After:

![image](https://github.com/user-attachments/assets/531c5a3a-c2aa-43a2-b571-214a0b8a1999)
![image](https://github.com/user-attachments/assets/48612dd6-711d-451c-9b4e-f4cee79a742e)
![image](https://github.com/user-attachments/assets/2f126ca0-d698-49d0-9c66-af4f8bf8cdd3)

---

RA Leaderboard Before:

![image](https://github.com/user-attachments/assets/352875c8-4c4c-488e-8e09-838d78bcaf6a)
![image](https://github.com/user-attachments/assets/47ba6f05-a325-433b-b514-9668712b8d68)


RA Leaderboard After:

![image](https://github.com/user-attachments/assets/8217afd7-a014-4115-a550-8ff636b48411)
![image](https://github.com/user-attachments/assets/8ac8b0d4-30bb-47a0-87d1-6ac6ef4ff9c1)


![image](https://github.com/user-attachments/assets/7394c216-e577-4b77-9acb-246c27e5e2a5)

---

9Bit Leaderboard Before:

![image](https://github.com/user-attachments/assets/70533cf1-2009-4928-bdca-b6f69e68c8d4)
![image](https://github.com/user-attachments/assets/2a9709d8-66ab-40c9-be15-1003284ec78f)


9Bit Leaderboard After:

![image](https://github.com/user-attachments/assets/cdc96b08-73e5-477f-bd52-4c484e25d747)
![image](https://github.com/user-attachments/assets/70250515-79eb-4491-9f76-c23720716ff0)


