### PR TITLE
Using dynamic href url for other-cnc-games

### DIFF
--- a/src/resources/views/games/components/generic-box-item.blade.php
+++ b/src/resources/views/games/components/generic-box-item.blade.php
@@ -1,17 +1,17 @@
 <article class="item generic-box-item">
     <div class="image">
-        <a href="https://cnc-comm.com/sole-survivor" title="{{ $title }}" rel="nofollow noreferrer" target="_blank" class="image-link">
+        <a href="{{ $url }}" title="{{ $title }}" rel="nofollow noreferrer" target="_blank" class="image-link">
             <img src="{{ Vite::asset($image) }}" alt="{{ $title }}" loading="lazy">
         </a>
 
         <div class="button">
-            <a href="https://cnc-comm.com/sole-survivor" title="{{ $title }}" rel="nofollow noreferrer" target="_blank" class="btn-link">
+            <a href="{{ $url }}" title="{{ $title }}" rel="nofollow noreferrer" target="_blank" class="btn-link">
                 <i class="icon-link"></i>
             </a>
         </div>
         <div>
             <h3 class="title">
-                <a href="https://cnc-comm.com/sole-survivor" title="{{ $title }}" rel="nofollow noreferrer" target="_blank">
+                <a href="{{ $url }}" title="{{ $title }}" rel="nofollow noreferrer" target="_blank">
                     {{ $title }}
                 </a>
             </h3>


### PR DESCRIPTION
PR should be tested locally before approval, unable to run on current local setup to validate.
Potentially needs extra logic to propagate the URL value, but should be OK.

--

Issue reported via Discord by Plok:

https://cnc.community/other-cnc-games
All of these lead to Sole Survivor 🤔

---

Source code has them with individuals links:
https://github.com/cnc-community/cnc.community/blob/81cf0ac0961e66be4ac05f0c04afe398aaaa602a/src/resources/views/games/category-more.blade.php

However the generic component had the hardcoded value instead of dynamic $url:
https://github.com/cnc-community/cnc.community/blob/81cf0ac0961e66be4ac05f0c04afe398aaaa602a/src/resources/views/games/components/generic-box-item.blade.php

